### PR TITLE
Cleaned up pluginManagement etc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,15 @@
                     <groupId>org.microbean</groupId>
                     <artifactId>helm-maven-plugin</artifactId>
                     <version>${helm.maven.plugin.version}</version>
+                    <configuration>
+                        <version>1</version>
+                        <releaseName>${project.artifactId}</releaseName>
+                        <releaseDiscoveryListeners>
+                            <abstractDiscoveryListener/>
+                        </releaseDiscoveryListeners>
+                        <namespace>${k8s.namespace}</namespace>
+                        <releaseNamespace>${k8s.namespace}</releaseNamespace>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -34,37 +43,10 @@
             <plugin>
                 <groupId>org.microbean</groupId>
                 <artifactId>helm-maven-plugin</artifactId>
-                <version>${helm.maven.plugin.version}</version>
+                <inherited>false</inherited>
                 <configuration>
-                    <version>1</version>
-                    <releaseName>${project.artifactId}</releaseName>
-                    <releaseDiscoveryListeners>
-                        <abstractDiscoveryListener/>
-                    </releaseDiscoveryListeners>
-                    <namespace>${k8s.namespace}</namespace>
-                    <releaseNamespace>${k8s.namespace}</releaseNamespace>
+                    <skip>true</skip>
                 </configuration>
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<phase>package</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>install</goal>-->
-                        <!--</goals>-->
-                        <!--<configuration>-->
-                            <!--&lt;!&ndash;none required&ndash;&gt;-->
-                        <!--</configuration>-->
-                    <!--</execution>-->
-                    <!--<execution>-->
-                        <!--<phase>package</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>status</goal>-->
-                        <!--</goals>-->
-                        <!--<configuration>-->
-                            <!--<releaseName>mandatory</releaseName>-->
-                            <!--<version>1</version>-->
-                        <!--</configuration>-->
-                    <!--</execution>-->
-                <!--</executions>-->
             </plugin>
         </plugins>
         <extensions>

--- a/sub_demo_1/pom.xml
+++ b/sub_demo_1/pom.xml
@@ -13,7 +13,6 @@
     <artifactId>sub_demo_1</artifactId>
 
     <properties>
-        <helm.maven.plugin.version>2.7.0.1.0.33</helm.maven.plugin.version>
         <k8s.namespace>sub-demo-1</k8s.namespace>
     </properties>
 

--- a/sub_demo_2/pom.xml
+++ b/sub_demo_2/pom.xml
@@ -13,7 +13,6 @@
     <artifactId>sub_demo_2</artifactId>
 
     <properties>
-        <helm.maven.plugin.version>2.7.0.1.0.33</helm.maven.plugin.version>
         <k8s.namespace>sub-demo-2</k8s.namespace>
     </properties>
 

--- a/sub_demo_3/pom.xml
+++ b/sub_demo_3/pom.xml
@@ -13,7 +13,6 @@
     <artifactId>sub_demo_3</artifactId>
 
     <properties>
-        <helm.maven.plugin.version>2.7.0.1.0.33</helm.maven.plugin.version>
         <k8s.namespace>sub-demo-3</k8s.namespace>
     </properties>
 
@@ -22,15 +21,8 @@
             <plugin>
                 <groupId>org.microbean</groupId>
                 <artifactId>helm-maven-plugin</artifactId>
-                <version>${helm.maven.plugin.version}</version>
                 <configuration>
-                    <version>1</version>
-                    <releaseName>${project.artifactId}</releaseName>
-                    <releaseDiscoveryListeners>
-                        <abstractDiscoveryListener/>
-                    </releaseDiscoveryListeners>
-                    <namespace>${k8s.namespace}</namespace>
-                    <skip>true</skip>
+                  <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Hi; here's a way to reduce configuration boilerplate while still accomplishing I think what you want.

In short, `<pluginManagement>` is like a template: it is information that will be "stamped" into place whenever a plugin matching its coordinates is invoked.  So it is kind of like a "class" in object-oriented parlance.

An "instance" would be a `<plugin>` stanza under `<build><plugins>`.

This PR establishes a default "template" configuration under `<pluginManagement>` in the parent pom.  This is then implicitly applied whenever an invocation of the helm-maven-plugin occurs.  In the parent pom, we also add a `<build><plugins><plugin>` invocation for it that has `skip` set to `true`.  This ensures that, e.g., `helm:install` is not actually run on the parent project (which is nonsensical).  We also ensure that this particular "instance" is not inherited by child poms.

Next, we deliberately do _not_ add _any_ information to `sub_demo_1` or `sub_demo_2`.  The net effect is that any invocation of the helm maven plugin will simply use the "template" configuration inherited by way of `<pluginManagement>`.  That means that `skip` is implicitly `false`.

Next, in `sub_demo_3`, we ensure that there is a skeletal `<configuration>` set up for helm maven plugin invocations in there.  Its `skip` parameter is set to `true`.

The net effect is that `helm:install` from the root will:
* Not run in the parent project.
* Run in `sub_demo_1` (it fails for me because your project as it currently exists doesn't do any copying or anything like that, so there's no `target` directory, but it doesn't fail due to `skip` issues or plugin configuration)
* Run in `sub_demo_2`
* Not run in `sub_demo_3`.

I've also removed redundant version information etc.

Hope this helps.